### PR TITLE
feat: improve draggable category panels in ClickGui and HudEditor

### DIFF
--- a/src/main/java/me/kiriyaga/nami/feature/gui/screen/ClickGuiScreen.java
+++ b/src/main/java/me/kiriyaga/nami/feature/gui/screen/ClickGuiScreen.java
@@ -26,6 +26,8 @@ public class ClickGuiScreen extends Screen {
     private final Map<ModuleCategory, CategoryPanel> categoryPanels = new HashMap<>();
     private boolean draggingCategory = false;
     private ModuleCategory draggedModuleCategory = null;
+    private int dragStartX, dragStartY;
+    private int initialCategoryX, initialCategoryY;
     public float scale = 1;
     private Screen previousScreen = null;
     private static final long FADE_DURATION_MS = 122L;
@@ -206,6 +208,10 @@ public class ClickGuiScreen extends Screen {
                     playClickSound();
                     draggingCategory = true;
                     draggedModuleCategory = moduleCategory;
+                    dragStartX = scaledMouseX;
+                    dragStartY = scaledMouseY;
+                    initialCategoryX = pos.x;
+                    initialCategoryY = pos.y;
                     return true;
                 }
             }
@@ -289,13 +295,12 @@ public class ClickGuiScreen extends Screen {
     public boolean mouseDragged(double mouseX, double mouseY, int button, double deltaX, double deltaY) {
         int scaledMouseX = (int) (mouseX / scale);
         int scaledMouseY = (int) (mouseY / scale);
-        int scaledDeltaX = (int) (deltaX / scale);
-        int scaledDeltaY = (int) (deltaY / scale);
 
         if (draggingCategory && draggedModuleCategory != null) {
             Point currentPos = categoryPositions.get(draggedModuleCategory);
             if (currentPos != null) {
-                currentPos.translate(scaledDeltaX, scaledDeltaY);
+                currentPos.x = initialCategoryX + (scaledMouseX - dragStartX);
+                currentPos.y = initialCategoryY + (scaledMouseY - dragStartY);
                 return true;
             }
         }

--- a/src/main/java/me/kiriyaga/nami/feature/gui/screen/HudEditorScreen.java
+++ b/src/main/java/me/kiriyaga/nami/feature/gui/screen/HudEditorScreen.java
@@ -27,6 +27,8 @@ public class HudEditorScreen extends Screen {
 
     private boolean draggingCategory = false;
     private ModuleCategory draggedModuleCategory = null;
+    private int dragStartX, dragStartY;
+    private int initialCategoryX, initialCategoryY;
 
     private HudElementModule draggingElement = null;
     private int dragOffsetX, dragOffsetY;
@@ -173,6 +175,10 @@ public class HudEditorScreen extends Screen {
                 playClickSound();
                 draggingCategory = true;
                 draggedModuleCategory = hudCategory;
+                dragStartX = scaledMouseX;
+                dragStartY = scaledMouseY;
+                initialCategoryX = pos.x;
+                initialCategoryY = pos.y;
                 return true;
             }
         }
@@ -239,13 +245,12 @@ public class HudEditorScreen extends Screen {
     public boolean mouseDragged(double mouseX, double mouseY, int button, double deltaX, double deltaY) {
         int scaledMouseX = (int) (mouseX / CLICK_GUI.scale);
         int scaledMouseY = (int) (mouseY / CLICK_GUI.scale);
-        int scaledDeltaX = (int) (deltaX / CLICK_GUI.scale);
-        int scaledDeltaY = (int) (deltaY / CLICK_GUI.scale);
 
         if (draggingCategory && draggedModuleCategory != null) {
             Point pos = categoryPositions.get(draggedModuleCategory);
             if (pos != null) {
-                pos.translate(scaledDeltaX, scaledDeltaY);
+                pos.x = initialCategoryX + (scaledMouseX - dragStartX);
+                pos.y = initialCategoryY + (scaledMouseY - dragStartY);
                 return true;
             }
         }


### PR DESCRIPTION
Previously, dragging category panels in both the ClickGui and HudEditor screens
resulted in imprecise and jittery movement. This was caused by the drag logic
incrementally applying mouse delta values, which accumulated small errors and
led to inconsistent positioning.

This commit refactors the drag mechanism to calculate the panel's new position
based on the initial click coordinates and the current mouse position. This
ensures smoother and more accurate panel movement during dragging.