### PR TITLE
fix navigation panel text vertical alignment

### DIFF
--- a/src/main/java/namidevelopment/kiriyaga/nami/impl/gui/newgui/component/NavigatePanelComponent.java
+++ b/src/main/java/namidevelopment/kiriyaga/nami/impl/gui/newgui/component/NavigatePanelComponent.java
@@ -65,7 +65,7 @@ public class NavigatePanelComponent {
                     context,
                     name,
                     offsetX,
-                    (y + (HEIGHT - FONT_SERVICE.getHeight()) / 2),
+                    (y + Math.ceilDiv(HEIGHT - FONT_SERVICE.getHeight(), 2)),
                     CLICK_GUI_SCREEN.applyFade(toRGBA(textCol)),
                     true
             );


### PR DESCRIPTION
caused by integer divison

before:
<img width="433" height="36" alt="image" src="https://github.com/user-attachments/assets/adc4f944-e46d-4a85-b982-3842559455ed" />

after:
<img width="429" height="33" alt="image" src="https://github.com/user-attachments/assets/9f1c145a-e5de-42f9-b00c-9c8979e72af2" />
