### PR TITLE
fix: Crystal aura

### DIFF
--- a/nami-client/src/main/java/namidevelopment/kiriyaga/nami/impl/feature/combat/AutoCrystalFeature.java
+++ b/nami-client/src/main/java/namidevelopment/kiriyaga/nami/impl/feature/combat/AutoCrystalFeature.java
@@ -122,7 +122,7 @@ public class AutoCrystalFeature extends Feature {
         placeAntiFeetTrap.setShowCondition(() -> doPlace.get() && page.get() == Page.PLACE);
         placeAntiFeetTrapFactor.setShowCondition(() -> doPlace.get() && page.get() == Page.PLACE && placeAntiFeetTrap.get());
 
-        noSelfPop.setShowCondition(() ->  page.get() == Page.DAMAGES);
+        noSelfPop.setShowCondition(() -> page.get() == Page.DAMAGES);
         minDamage.setShowCondition(() -> page.get() == Page.DAMAGES);
         maxSelfDamage.setShowCondition(() -> page.get() == Page.DAMAGES);
         maxFriendDamage.setShowCondition(() -> page.get() == Page.DAMAGES);
@@ -287,7 +287,7 @@ public class AutoCrystalFeature extends Feature {
 
 
             float totalDamage = damageOthers(crystal);
-            if (totalDamage <= -0.9f)
+            if (totalDamage < minDamage.get())
                 continue;
 
             if (best == null || totalDamage > best.totalDamage)


### PR DESCRIPTION
I think this is fixing the following issue: the crystal aura would break crystals even if no enemy was next to it.
(btw sorry for the 2 commits)