### PR TITLE
Fix: Target Java 21 for Minecraft compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,3 +12,9 @@ tasks.register("client") {
     group = "run"
     dependsOn(":client:runClient")
 }
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+	id 'java'
 }
 
 allprojects {

--- a/nami-client/build.gradle
+++ b/nami-client/build.gradle
@@ -1,6 +1,8 @@
 plugins {
     id 'fabric-loom' version '1.15.3'
     id 'maven-publish'
+    id 'java'
+
 }
 
 repositories {
@@ -57,4 +59,10 @@ dependencies {
 
     modImplementation "namidevelopment.kiriyaga:nami-api:${namiApiVersion}"
     include "namidevelopment.kiriyaga:nami-api:${namiApiVersion}"
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }


### PR DESCRIPTION
Set Java toolchain to version 21 in client build configuration. Minecraft 1.21.11 requires Java 21, not Java 23.