### PR TITLE
build: remove required PAT auth when building a client

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The default command prefix is `-`.
     ```
 
 The compiled JAR will be located at:  
-`build/libs/nami-<version>.jar`
+`./<project>/build/libs/nami-<version>.jar`
 
 nami-client is packaged with nami-api inside of it.
 

--- a/README.md
+++ b/README.md
@@ -83,15 +83,13 @@ The default command prefix is `-`.
 
 1. Clone the repository:
 
-    ```bash
+    ```sh
     git clone https://github.com/NamiDevelopment/Nami.git  
     cd nami
     ```
-2. In order to get nami-api dependency,you need to configure your PAT-token in your root .gradle/gradle.dependency
+2. Build with Gradle:
 
-3. Build with Gradle:
-
-    ```bash
+    ```sh
     ./gradlew build
     ```
 

--- a/nami-client/build.gradle
+++ b/nami-client/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-    implementation project(path: ":nami-api", configuration: "namedElements")
+    include implementation(project(path: ":nami-api", configuration: "namedElements"))
 }
 
 java {

--- a/nami-client/build.gradle
+++ b/nami-client/build.gradle
@@ -6,24 +6,23 @@ plugins {
 }
 
 repositories {
-    maven {
-        url = uri("https://maven.pkg.github.com/NamiDevelopment/nami")
-        credentials {
-            username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_ACTOR")
-            password = project.findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
-        }
-    }
-
     maven { url = "https://maven.fabricmc.net/" }
-
     maven { url = "https://repo.spongepowered.org/maven" }
 
     mavenCentral()
-
 }
 
 loom {
     accessWidenerPath = file("src/main/resources/META-INF/nami.accesswidener")
+
+    mods {
+        "nami-api" {
+            sourceSet project(":nami-api").sourceSets.main
+        }
+        "nami-client" {
+            sourceSet sourceSets.main
+        }
+    }
 }
 
 processResources {
@@ -42,7 +41,6 @@ processResources {
 
 group = project.maven_group
 version = project.mod_version
-def namiApiVersion = project.nami_api
 
 tasks.register("printVersion") {
     doLast {
@@ -56,9 +54,7 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-
-    modImplementation "namidevelopment.kiriyaga:nami-api:${namiApiVersion}"
-    include "namidevelopment.kiriyaga:nami-api:${namiApiVersion}"
+    implementation project(path: ":nami-api", configuration: "namedElements")
 }
 
 java {


### PR DESCRIPTION
in my opinion you do not have to register a github account or provide git pat token just for building a client from local source since its not convenient at all